### PR TITLE
remove flipper config

### DIFF
--- a/plugin/build/withPodfile.js
+++ b/plugin/build/withPodfile.js
@@ -35,8 +35,6 @@ const withPodfile = (config, { targetName, excludedPackages }) => {
             :fabric_enabled => flags[:fabric_enabled],
             # An absolute path to your application root.
             :app_path => "#{Pod::Config.instance.installation_root}/..",
-            # Note that if you have use_frameworks! enabled, Flipper will not work if enabled
-            :flipper_configuration => flipper_config
           )
         end
       `;

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -39,8 +39,6 @@ export const withPodfile: ConfigPlugin<{
             :fabric_enabled => flags[:fabric_enabled],
             # An absolute path to your application root.
             :app_path => "#{Pod::Config.instance.installation_root}/..",
-            # Note that if you have use_frameworks! enabled, Flipper will not work if enabled
-            :flipper_configuration => flipper_config
           )
         end
       `;


### PR DESCRIPTION
RN 0.74 no longer takes a flipper config in the `use_react_native` block of the `Podfile`. Removing that from the `withPodfile` step of the build plugin.